### PR TITLE
bcache: solve generic_start_io_acct() use rw not bio_op(bio) in linux…

### DIFF
--- a/drivers/md/bcache/request.c
+++ b/drivers/md/bcache/request.c
@@ -1236,10 +1236,7 @@ blk_qc_t cached_dev_make_request(struct request_queue *q, struct bio *bio)
 		}
 	}
 
-	generic_start_io_acct(q,
-			      bio_op(bio),
-			      bio_sectors(bio),
-			      &d->disk->part0);
+	generic_start_io_acct(q, rw, bio_sectors(bio), &d->disk->part0);
 
 	bio_set_dev(bio, dc->bdev);
 	bio->bi_iter.bi_sector += dc->sb.data_offset;


### PR DESCRIPTION
…-4.14